### PR TITLE
Fix gui script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2024-01-26
+
+### Fixed
+- Added a separate `rgb2mqtt-gui-run` gui-script, so using the normal `rgb2mqtt-run` script now functions as a console script. This makes it easier to debug the run script, since stdout in a gui-script is lost.
+The gui-script is only used for auto-start, which prevents a terminal popup on Windows.
+
 ## [1.0.1] - 2024-01-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "Ruben Peters", email = "rubenpeters91@protonmail.com"}
 ]
 readme = "README.md"
-version = "1.0.1"
+version = "1.1.0"
 license = {text = "MIT"}
 requires-python = ">=3.7"
 classifiers = [
@@ -30,12 +30,13 @@ dev = ["black", "ruff", "isort"]
 [project.urls]
 Homepage = "https://github.com/rubenpeters91/rgb2mqtt"
 
-[project.gui-scripts]
-rgb2mqtt-run = "rgb2mqtt.run:run_rgb2mqtt"
-
 [project.scripts]
 rgb2mqtt-config = "rgb2mqtt.setup:setup_rgb2mqtt"
 rgb2mqtt-autostart = "rgb2mqtt.setup:copy_to_autostart"
+rgb2mqtt-run = "rgb2mqtt.run:run_rgb2mqtt"
+
+[project.gui-scripts]
+rgb2mqtt-gui-run = "rgb2mqtt.run:run_rgb2mqtt"
 
 [tool.isort]
 profile = "black"

--- a/src/rgb2mqtt/setup.py
+++ b/src/rgb2mqtt/setup.py
@@ -65,10 +65,10 @@ def copy_to_autostart() -> None:
         raise NotImplementedError()
 
     script_path = (
-        Path(sysconfig.get_path("scripts", f"{os.name}_user")) / "rgb2mqtt-run.exe"
+        Path(sysconfig.get_path("scripts", f"{os.name}_user")) / "rgb2mqtt-gui-run.exe"
     )
     if not script_path.exists():
-        script_path = Path(sysconfig.get_path("scripts")) / "rgb2mqtt-run.exe"
+        script_path = Path(sysconfig.get_path("scripts")) / "rgb2mqtt-gui-run.exe"
         if not script_path.exists():
             raise Exception(
                 "Can't find installed run script, did you run 'pip install'?"
@@ -81,7 +81,7 @@ def copy_to_autostart() -> None:
         / "Start Menu"
         / "Programs"
         / "Startup"
-        / "rgb2mqtt-run.exe"
+        / "rgb2mqtt-gui-run.exe"
     )
     if target_file.exists():
         logger.error("Script already in autostart!")


### PR DESCRIPTION
- Added a separate `rgb2mqtt-gui-run` gui-script, so using the normal `rgb2mqtt-run` script now functions as a console script. This makes it easier to debug the run script, since stdout in a gui-script is lost.
The gui-script is only used for auto-start, which prevents a terminal popup on Windows.